### PR TITLE
Add _target_batch_dim

### DIFF
--- a/inferno/trainers/basic.py
+++ b/inferno/trainers/basic.py
@@ -614,6 +614,21 @@ class Trainer(object):
     def epoch_count(self):
         return self._epoch_count
 
+    @property
+    def target_batch_dim(self):
+        return self._target_batch_dim
+
+    @target_batch_dim.setter
+    def target_batch_dim(self, value):
+        assert_(value in [0, 1],
+                f"target_batch_dim must be either 0 or 1, got {value} instead.",
+                ValueError)
+        self._target_batch_dim = value
+
+    def set_target_batch_dim(self, value):
+        self.target_batch_dim = value
+        return self
+
     def build_logger(self, logger=None, log_directory=None, **kwargs):
         """
         Build the logger.

--- a/inferno/trainers/basic.py
+++ b/inferno/trainers/basic.py
@@ -84,6 +84,7 @@ class Trainer(object):
         self._is_iteration_with_best_validation_score = False
         self._validate_every = None
         self._num_validation_iterations = None
+        self._target_batch_dim = 0
         # We should exclude the zero-th epoch from validation
         self._last_validated_at_epoch = 0
         self._last_validated_at_iteration = 0
@@ -1305,7 +1306,7 @@ class Trainer(object):
                 inputs, target = self.split_batch(batch, from_loader=loader_name)
                 # Apply model, compute loss
                 output, loss = self.apply_model_and_loss(inputs, target, backward=False)
-            batch_size = target.size(0)
+            batch_size = target.size(self._target_batch_dim)
             validation_loss_meter.update(loss.data[0], n=batch_size)
             # Compute validation_error
             if self.metric_is_defined:


### PR DESCRIPTION
Trainer assumes batch dimension is first, so I'm getting incorrect validation results for sequence data (batch dimension is second).

This PR adds a private attribute for the batch dimension that defaults to 0 instead of hard-coded 0.

If you're using some sort of sequence data, just use `trainer._target_batch_dim = 1`.

Cheers