### PR TITLE
Fix pip version in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     # TODO: put package requirements here
-    "pip==8.1.2",
+    "pip>=8.1.2",
     "torch>=0.1.12",
     "dill",
     "pyyaml",


### PR DESCRIPTION
Thanks for an awesome library. I've been teaching everyone to use it in class. 

However, I'm tired of accidentally downgrading pip when I install. This changes the == to a >=.