### PR TITLE
Fix scalar detection

### DIFF
--- a/inferno/utils/torch_utils.py
+++ b/inferno/utils/torch_utils.py
@@ -70,7 +70,7 @@ def is_matrix_tensor(object_):
 
 
 def is_scalar_tensor(object_):
-    return is_tensor(object_) and object_.dim() == 1 and object_.numel() == 1
+    return is_tensor(object_) and object_.dim() <= 1 and object_.numel() == 1
 
 
 def assert_same_size(tensor_1, tensor_2):


### PR DESCRIPTION
Losses tend to be 0 dim in the newest pytorch. Changed scalar detection to dim<=1 instead of dim==1.

Without this fix, losses do not get logged.

Cheers!