### PR TITLE
Set train and eval for criterion and metric if appropriate

### DIFF
--- a/inferno/trainers/basic.py
+++ b/inferno/trainers/basic.py
@@ -422,6 +422,22 @@ class Trainer(object):
         """Checks if the metric is defined."""
         return self._metric is not None
 
+    def eval_mode(self):
+        """Set model, criterion and metric to eval mode"""
+        self.model.eval()
+        if self.criterion_is_defined and isinstance(self.criterion, torch.nn.Module):
+            self.criterion.eval()
+        if self.metric_is_defined and isinstance(self.metric, torch.nn.Module):
+            self.metric.eval()
+
+    def train_mode(self):
+        """Set model, criterion and metric to train mode"""
+        self.model.train()
+        if self.criterion_is_defined and isinstance(self.criterion, torch.nn.Module):
+            self.criterion.train()
+        if self.metric_is_defined and isinstance(self.metric, torch.nn.Module):
+            self.metric.train()
+
     @property
     def train_loader(self):
         assert self._loaders.get('train') is not None
@@ -1180,7 +1196,7 @@ class Trainer(object):
 
     def train_for(self, num_iterations=None, break_callback=None):
         # Switch model to train mode
-        self.model.train()
+        self.train_mode()
         # Call callback
         self.callbacks.call(self.callbacks.BEGIN_OF_TRAINING_RUN,
                             num_iterations=num_iterations)
@@ -1280,7 +1296,7 @@ class Trainer(object):
             self._num_validation_iterations if num_iterations is None else num_iterations
 
         # Switch to eval mode (e.g. for batchnorm, etc.)
-        self.model.eval()
+        self.eval_mode()
 
         # Record the epoch we're validating in
         self._last_validated_at_epoch = self._epoch_count


### PR DESCRIPTION
Set train and eval for model, criterion, and metric (if the latter 2 exist and are Modules).

Example use case is I've got cross entropy with smoothing. I want to smooth the loss during training, but I don't want to apply smoothing during testing.

Called the functions `eval_mode` and `train_mode` so it is obvious that the function doesn't actually do any training or evaluating.