### PR TITLE
Framework for regularization losses

### DIFF
--- a/examples/regularized_mnist.py
+++ b/examples/regularized_mnist.py
@@ -1,0 +1,113 @@
+import argparse
+import sys
+
+import torch
+import torch.nn as nn
+from torchvision import datasets, transforms
+
+from inferno.extensions.criteria.regularized import RegularizedCrossEntropyLoss
+from inferno.extensions.layers.reshape import Flatten
+from inferno.trainers.basic import Trainer
+from inferno.trainers.callbacks.logging.tensorboard import TensorboardLogger
+
+
+class RegularizedLinear(nn.Linear):
+    def __init__(self, *args, ar_weight=1e-3, l1_weight=1e-3, **kwargs):
+        super(RegularizedLinear, self).__init__(*args, **kwargs)
+        self.ar_weight = ar_weight
+        self.l1_weight = l1_weight
+        self._losses = {}
+
+    def forward(self, input):
+        output = super(RegularizedLinear, self).forward(input)
+        self._losses['activity_regularization'] = (output * output).sum() * self.ar_weight
+        self._losses['l1_weight_regularization'] = torch.abs(self.weight).sum() * self.l1_weight
+        return output
+
+
+def model_fn():
+    return nn.Sequential(
+        Flatten(),
+        RegularizedLinear(in_features=784, out_features=256),
+        nn.LeakyReLU(),
+        RegularizedLinear(in_features=256, out_features=128),
+        nn.LeakyReLU(),
+        RegularizedLinear(in_features=128, out_features=10)
+    )
+
+
+def mnist_data_loaders(args):
+    kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
+    train_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('./data', train=True, download=True,
+                       transform=transforms.Compose([
+                           transforms.ToTensor(),
+                           transforms.Normalize((0.1307,), (0.3081,))
+                       ])),
+        batch_size=args.batch_size, shuffle=True, **kwargs)
+    test_loader = torch.utils.data.DataLoader(
+        datasets.MNIST('./data', train=False, transform=transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.1307,), (0.3081,))
+        ])),
+        batch_size=args.test_batch_size, shuffle=True, **kwargs)
+    return train_loader, test_loader
+
+
+def train_model(args):
+    model = model_fn()
+    train_loader, validate_loader = mnist_data_loaders(args)
+
+    # Build trainer
+    trainer = Trainer(model) \
+        .build_criterion(RegularizedCrossEntropyLoss) \
+        .build_metric('CategoricalError') \
+        .build_optimizer('Adam') \
+        .validate_every((1, 'epochs')) \
+        .save_every((1, 'epochs')) \
+        .save_to_directory(args.save_directory) \
+        .set_max_num_epochs(args.epochs) \
+        .build_logger(TensorboardLogger(log_scalars_every=(1, 'iteration'),
+                                        log_images_every='never'),
+                      log_directory=args.save_directory)
+
+    # Record regularization losses
+    trainer.logger.observe_training_and_validation_states([
+        'main_loss',
+        'total_regularization_loss',
+        'activity_regularization',
+        'l1_weight_regularization'
+    ])
+
+    # Bind loaders
+    trainer \
+        .bind_loader('train', train_loader) \
+        .bind_loader('validate', validate_loader)
+
+    if args.cuda:
+        trainer.cuda()
+
+    # Go!
+    trainer.fit()
+
+
+def main(argv):
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--save-directory', type=str, default='output/mnist/v1',
+                        help='output directory')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=20, metavar='N',
+                        help='number of epochs to train (default: 20)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    args = parser.parse_args(argv)
+    args.cuda = not args.no_cuda and torch.cuda.is_available()
+    train_model(args)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/examples/regularized_mnist.py
+++ b/examples/regularized_mnist.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 from torchvision import datasets, transforms
 
-from inferno.extensions.criteria.regularized import RegularizedCrossEntropyLoss
 from inferno.extensions.layers.reshape import Flatten
 from inferno.trainers.basic import Trainer
 from inferno.trainers.callbacks.logging.tensorboard import TensorboardLogger
@@ -60,7 +59,7 @@ def train_model(args):
 
     # Build trainer
     trainer = Trainer(model) \
-        .build_criterion(RegularizedCrossEntropyLoss) \
+        .build_criterion('RegularizedCrossEntropyLoss') \
         .build_metric('CategoricalError') \
         .build_optimizer('Adam') \
         .validate_every((1, 'epochs')) \

--- a/inferno/extensions/criteria/__init__.py
+++ b/inferno/extensions/criteria/__init__.py
@@ -1,2 +1,3 @@
-from .set_similarity_measures import *
 from .core import *
+from .regularized import *
+from .set_similarity_measures import *

--- a/inferno/extensions/criteria/regularized.py
+++ b/inferno/extensions/criteria/regularized.py
@@ -5,6 +5,15 @@ from torch import nn
 
 from . import set_similarity_measures, core
 
+__all__ = [
+    'RegularizedLoss',
+    'RegularizedCrossEntropyLoss',
+    'RegularizedBCEWithLogitsLoss',
+    'RegularizedBCELoss',
+    'RegularizedMSELoss',
+    'RegularizedNLLLoss'
+]
+
 
 def collect_losses(module):
     """Collect `_losses` dictionaries from module and children
@@ -52,6 +61,7 @@ def build_criterion(criterion, *args, **kwargs):
 class RegularizedLoss(nn.Module):
     """Wrap a criterion. Collect regularization losses from model and combine with wrapped criterion.
     """
+
     def __init__(self, criterion, *args, **kwargs):
         super(RegularizedLoss, self).__init__()
         self.criterion = build_criterion(criterion, *args, **kwargs)
@@ -63,12 +73,12 @@ class RegularizedLoss(nn.Module):
         # If no trainer, we cannot record states
         if trainer is None:
             warnings.warn('No trainer parameter provided. Not logging regularization losses.')
-        else:
+        elif model is None:
             model = trainer.model
 
         # If no model or trainer, we cannot record states or collect losses
         if model is None:
-            warnings.warn('No model parameter provided. Not calculating regularization losses.')
+            warnings.warn('No model or trainer parameter provided. Not calculating regularization losses.')
             regularization_losses = {}
             total_regularization_loss = None
             total_loss = main_loss

--- a/inferno/extensions/criteria/regularized.py
+++ b/inferno/extensions/criteria/regularized.py
@@ -1,0 +1,124 @@
+import warnings
+
+import torch
+from torch import nn
+
+from . import set_similarity_measures, core
+
+
+def collect_losses(module):
+    """Collect `_losses` dictionaries from module and children
+
+    :param module: a Module to be searched for losses
+    :return: dictionary of loss names to values
+    """
+    losses = {}
+
+    def _collect(m):
+        if hasattr(m, '_losses'):
+            for k, v in m._losses.items():
+                if k in losses:
+                    losses[k] = losses[k] + v
+                else:
+                    losses[k] = v
+
+    module.apply(_collect)
+    return losses
+
+
+def build_criterion(criterion, *args, **kwargs):
+    """Build a criterion
+
+    :param criterion: criterion class, name of criterion class, or instance of criterion
+    :param args: args for constructor
+    :param kwargs: kwargs for constructor
+    :return: instance of criterion
+    """
+    if isinstance(criterion, str):
+        for module in [nn, core, set_similarity_measures]:
+            criterion_class = getattr(module, criterion, None)
+            if criterion_class is not None:
+                break
+        assert criterion_class is not None, "Criterion {} not found.".format(criterion)
+    elif callable(criterion) and isinstance(criterion, type):
+        criterion_class = criterion
+    elif isinstance(criterion, torch.nn.Module):
+        return criterion
+    else:
+        raise NotImplementedError
+    return criterion_class(*args, **kwargs)
+
+
+class RegularizedLoss(nn.Module):
+    """Wrap a criterion. Collect regularization losses from model and combine with wrapped criterion.
+    """
+    def __init__(self, criterion, *args, **kwargs):
+        super(RegularizedLoss, self).__init__()
+        self.criterion = build_criterion(criterion, *args, **kwargs)
+
+    def forward(self, *args, trainer=None, model=None, **kwargs):
+        # calculate wrapped loss
+        main_loss = self.criterion(*args, **kwargs)
+
+        # If no trainer, we cannot record states
+        if trainer is None:
+            warnings.warn('No trainer parameter provided. Not logging regularization losses.')
+        else:
+            model = trainer.model
+
+        # If no model or trainer, we cannot record states or collect losses
+        if model is None:
+            warnings.warn('No model parameter provided. Not calculating regularization losses.')
+            regularization_losses = {}
+            total_regularization_loss = None
+            total_loss = main_loss
+        else:
+            regularization_losses = collect_losses(model)
+            total_regularization_loss = sum(regularization_losses.values())
+            total_loss = main_loss + total_regularization_loss
+
+        # Record losses if trainer provided
+        if trainer is not None:
+            # prefix depending on mode
+            if self.training:
+                prefix = 'training'
+            else:
+                prefix = 'validation'
+            # main loss
+            updates = {'{}_main_loss'.format(prefix): main_loss}
+            # total regulariztion loss
+            if total_regularization_loss is not None:
+                updates['{}_total_regularization_loss'.format(prefix)] = total_regularization_loss
+            # detailed regularization losses
+            for k, v in regularization_losses.items():
+                updates['{}_{}'.format(prefix, k)] = v
+            # record state
+            trainer.update_state_from_dictionary(updates)
+
+        return total_loss
+
+
+# Convenience wrappers for common losses
+class RegularizedCrossEntropyLoss(RegularizedLoss):
+    def __init__(self, *args, **kwargs):
+        super(RegularizedCrossEntropyLoss, self).__init__(nn.CrossEntropyLoss, *args, **kwargs)
+
+
+class RegularizedBCEWithLogitsLoss(RegularizedLoss):
+    def __init__(self, *args, **kwargs):
+        super(RegularizedBCEWithLogitsLoss, self).__init__(nn.BCEWithLogitsLoss, *args, **kwargs)
+
+
+class RegularizedBCELoss(RegularizedLoss):
+    def __init__(self, *args, **kwargs):
+        super(RegularizedBCELoss, self).__init__(nn.BCELoss, *args, **kwargs)
+
+
+class RegularizedMSELoss(RegularizedLoss):
+    def __init__(self, *args, **kwargs):
+        super(RegularizedMSELoss, self).__init__(nn.MSELoss, *args, **kwargs)
+
+
+class RegularizedNLLLoss(RegularizedLoss):
+    def __init__(self, *args, **kwargs):
+        super(RegularizedNLLLoss, self).__init__(nn.NLLLoss, *args, **kwargs)

--- a/inferno/trainers/callbacks/logging/tensorboard.py
+++ b/inferno/trainers/callbacks/logging/tensorboard.py
@@ -146,9 +146,18 @@ class TensorboardLogger(Logger):
             raise NotImplementedError
         return self
 
+    def observe_training_and_validation_state(self, key):
+        for mode in ['training', 'validation']:
+            self.observe_state('{}_{}'.format(mode, key), observe_while=mode)
+
     def observe_states(self, keys, observe_while='training'):
         for key in keys:
             self.observe_state(key, observe_while=observe_while)
+        return self
+
+    def observe_training_and_validation_states(self, keys):
+        for key in keys:
+            self.observe_training_and_validation_state(key)
         return self
 
     def log_object(self, tag, object_, allow_scalar_logging=True, allow_image_logging=True):


### PR DESCRIPTION
This provides some organization for collecting regularization losses.
- Any module can have an attribute `_losses`, which is a dictionary of names to losses
- `RegularizedLoss` collects all the losses from all the modules and adds it to the main loss.

Check regularized_mnist.py for an example of how it works. Code to use is relatively minimal. You get a nice tensorboard of all of the training and validation losses. (in combination with https://github.com/inferno-pytorch/inferno/pull/110)

Please let me know your thoughts on ways to approach this. I love the easy way TF organizes all your losses and inferno needs something similar. Tricky part is that if a criterion wants to create detailed logs then it needs access to the trainer and model. Tried to do it as cleanly as possible but open to suggestions.