### PR TITLE
fix bug: pass **kwargs when building metric with string

### DIFF
--- a/inferno/trainers/basic.py
+++ b/inferno/trainers/basic.py
@@ -516,7 +516,7 @@ class Trainer(object):
         elif isinstance(method, str):
             assert hasattr(metrics, method), \
                 "Could not find the metric '{}'.".format(method)
-            self._metric = getattr(metrics, method)()
+            self._metric = getattr(metrics, method)(**kwargs)
         else:
             raise NotImplementedError
         return self


### PR DESCRIPTION
When building the metric with a string, the kwargs were not passed to the method.
This should fix it.