### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/inferno/extensions/containers/graph.py
+++ b/inferno/extensions/containers/graph.py
@@ -357,7 +357,7 @@ class Graph(nn.Module):
             modules.append(module)
         return pyu.from_iterable(modules)
 
-    def to_device(self, names, target_device, device_ordinal=None, async=False):
+    def to_device(self, names, target_device, device_ordinal=None, asynchron=False):
         """Transfer nodes in the network to a specified device."""
         names = pyu.to_iterable(names)
         for name in names:
@@ -368,7 +368,7 @@ class Graph(nn.Module):
             # Transfer
             module_on_device = OnDevice(module, target_device,
                                         device_ordinal=device_ordinal,
-                                        async=async)
+                                        asynchron=asynchron)
             setattr(self, name, module_on_device)
         return self
 

--- a/inferno/extensions/layers/device.py
+++ b/inferno/extensions/layers/device.py
@@ -7,7 +7,7 @@ _all = __all__
 
 class DeviceTransfer(nn.Module):
     """Layer to transfer variables to a specified device."""
-    def __init__(self, target_device, device_ordinal=None, async=False):
+    def __init__(self, target_device, device_ordinal=None, asynchron=False):
         """
         Parameters
         ----------
@@ -15,8 +15,8 @@ class DeviceTransfer(nn.Module):
             Device to transfer to.
         device_ordinal : int
             Device ordinal if target_device == 'cuda'.
-        async : bool
-            Whether to use async transfers.
+        asynchron : bool
+            Whether to use asynchronous transfers.
         """
         super(DeviceTransfer, self).__init__()
         # Validate arguments
@@ -29,11 +29,11 @@ class DeviceTransfer(nn.Module):
                     DeviceError)
         self.target_device = target_device
         self.device_ordinal = device_ordinal
-        self.async = async
+        self.asynchron = asynchron
 
     def forward(self, *inputs):
         if self.target_device == 'cuda':
-            transferred = tuple(input_.cuda(device_id=self.device_ordinal, async=self.async)
+            transferred = tuple(input_.cuda(device_id=self.device_ordinal, asynchron=self.asynchron)
                                 for input_ in inputs)
         elif self.target_device == 'cpu':
             transferred = tuple(input_.cpu() for input_ in inputs)
@@ -48,7 +48,7 @@ class OnDevice(nn.Module):
     that the inputs are transferred to the same device as the module, enabling easy model
     parallelism.
     """
-    def __init__(self, module, target_device, device_ordinal=None, async=False):
+    def __init__(self, module, target_device, device_ordinal=None, asynchron=False):
         """
         Parameters
         ----------
@@ -58,8 +58,8 @@ class OnDevice(nn.Module):
             The device to move `module` to. Must be either 'cuda' or 'cpu'.
         device_ordinal : int
             Ordinal of the GPU device if `target_device = 'cuda'`.
-        async : bool
-            Whether to use async transfers.
+        asynchron : bool
+            Whether to use asynchronous transfers.
         """
         super(OnDevice, self).__init__()
         # Validate arguments
@@ -72,11 +72,11 @@ class OnDevice(nn.Module):
                     DeviceError)
         self.target_device = target_device
         self.device_ordinal = device_ordinal
-        self.async = async
+        self.asynchron = asynchron
         # This is a no-op if module is already in the right device
         self.device_transfer = DeviceTransfer(self.target_device,
                                               device_ordinal=self.device_ordinal,
-                                              async=self.async)
+                                              asynchron=self.asynchron)
 
         self.module = self.transfer_module(module)
 


### PR DESCRIPTION
Renames `async` parameter (now a keyword, https://docs.python.org/3/library/asyncio-task.html) as `asynchron` for python 3.7 compatibility.