### PR TITLE
Fix tqdm serialization

### DIFF
--- a/inferno/trainers/callbacks/tqdm.py
+++ b/inferno/trainers/callbacks/tqdm.py
@@ -30,8 +30,7 @@ class TQDMProgressBar(Callback):
         self.is_validation = False
 
     def get_config(self):
-        config_dict = dict(self.__dict__)
-        config_dict.update({'_trainer': None})
+        config_dict = super(TQDMProgressBar, self).get_config()
         config_dict.update({'epoch_bar': None})
         config_dict.update({'outer_bar': None})
         return config_dict

--- a/inferno/trainers/callbacks/tqdm.py
+++ b/inferno/trainers/callbacks/tqdm.py
@@ -29,6 +29,13 @@ class TQDMProgressBar(Callback):
         self.is_training = False
         self.is_validation = False
 
+    def get_config(self):
+        config_dict = dict(self.__dict__)
+        config_dict.update({'_trainer': None})
+        config_dict.update({'epoch_bar': None})
+        config_dict.update({'outer_bar': None})
+        return config_dict
+
     def bind_trainer(self, *args, **kwargs):
         super(TQDMProgressBar, self).bind_trainer(*args, **kwargs)
         self.trainer.console.toggle_progress(False)


### PR DESCRIPTION
This removes the TQDM bar from the serialization.

It prevents the error when saving the trainer:
`TypeError: cannot serialize '_io.TextIOWrapper' object`

I think the bar will be rebuilt automatically (haven't tested it yet).