### PR TITLE
Conv 1d and unet refactoring

### DIFF
--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -56,10 +56,10 @@ if True:
     # # Visualize Dataset
     # # ~~~~~~~~~~~~~~~~~~~~~~
     fig = plt.figure()
-    for i,(noisy_signal, signal) in enumerate(train_loader):
+    for i,(noisy_signal, gt) in enumerate(train_loader):
         ax = fig.add_subplot(2, 2, i+1)
         ax.plot(numpy.arange(noisy_signal.size()[2]), noisy_signal.numpy()[0,0,...])#, 'ro')
-        ax.plot(numpy.arange(signal.size()[2]), signal.numpy()[0,0,...], 'r')
+        ax.plot(numpy.arange(gt.size()[2]), gt.numpy()[0,0,...], 'r')
         if i>=3 :
             break
     fig.tight_layout()
@@ -117,7 +117,7 @@ def predict(trainer, test_loader,  save_dir=None):
 
     trainer.eval_mode()
     c = 0
-    for noisy_signal, signal in test_loader:
+    for noisy_signal, gt in test_loader:
         if c > 2:
             break
         # transfer noisy_signal to gpu
@@ -131,7 +131,7 @@ def predict(trainer, test_loader,  save_dir=None):
 
         noisy_signal = unwrap(noisy_signal,      as_numpy=True, to_cpu=True)
         prediction = unwrap(prediction, as_numpy=True, to_cpu=True)
-        signal = unwrap(signal, as_numpy=True, to_cpu=True)
+        gt = unwrap(gt, as_numpy=True, to_cpu=True)
 
         for b in range(batch_size):
             fig = plt.figure()

--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -50,7 +50,7 @@ train_loader, test_loader, validate_loader = get_noisy_func_loader(
 image_channels = 1   # <-- number of channels of the image
 pred_channels = 1  # <-- number of channels needed for the prediction
 
-if True:
+if False:
 
     # ##############################################################################
     # # Visualize Dataset
@@ -86,7 +86,7 @@ def train_model(model, loaders, **kwargs):
     trainer.validate_every((kwargs.get('validate_every', 1), 'epochs'))
     #trainer.save_every((kwargs.get('save_every', 10), 'epochs'))
     #trainer.save_to_directory(ensure_dir(kwargs.get('save_dir', 'save_dor')))
-    trainer.set_max_num_epochs(kwargs.get('max_num_epochs', 40))
+    trainer.set_max_num_epochs(kwargs.get('max_num_epochs', 4))
 
     # bind the loaders
     trainer.bind_loader('train', loaders[0])
@@ -138,7 +138,7 @@ def predict(trainer, test_loader,  save_dir=None):
             rng = numpy.arange(prediction[b,...].size)
 
             ax = fig.add_subplot(1, 1, 1)
-            ax.plot(rng,noisy_signal[b,0,...],'r' , rng,signal[b,0,...],'g', rng, prediction[b,0,...],'b')
+            ax.plot(rng,noisy_signal[b,0,...],'r' , rng, gt[b,0,...],'g', rng, prediction[b,0,...],'b')
             fig.tight_layout()
             plt.show()
 
@@ -159,7 +159,7 @@ from inferno.extensions.models import *
 from inferno.extensions.layers import *
 
 
-unet = UNet( in_channels=1, out_channels=1, dim=1, depth=2)
+unet = UNet(in_channels=1, initial_features=64, out_channels=1, dim=1, depth=2)
 
 ##################################################
 # do the training 

--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -19,12 +19,13 @@ import numpy
 # determine whether we have a gpu
 # and should use cuda
 USE_CUDA = torch.cuda.is_available()
-
+print("USE_CUDA",USE_CUDA)
 
 ##############################################################################
 # Dataset
 # --------------
 # For simplicity we will use a toy dataset based on a noisy sine
+
 from inferno.io.box.noisy_func_1d import get_noisy_func_loader
 
 import math
@@ -159,7 +160,7 @@ from inferno.extensions.models import *
 from inferno.extensions.layers import *
 
 
-unet = UNet(in_channels=1, initial_features=64, out_channels=1, dim=1, depth=2)
+unet = UNet(in_channels=1, initial_features=64, out_channels=1, dim=1, depth=1)
 
 ##################################################
 # do the training 

--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -159,15 +159,11 @@ from inferno.extensions.models import *
 from inferno.extensions.layers import *
 
 
-
-
-model_b = UNet( in_channels=1, out_channels=1, dim=1, depth=2)
-
-
+unet = UNet( in_channels=1, out_channels=1, dim=1, depth=2)
 
 ##################################################
 # do the training 
-trainer = train_model(model=model_b, loaders=[train_loader, validate_loader], save_dir='model_b', lr=0.001)
+trainer = train_model(model=unet, loaders=[train_loader, validate_loader], save_dir='unet', lr=0.001)
 
 ###################################################
 # visualizer predictions

--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -24,7 +24,7 @@ USE_CUDA = torch.cuda.is_available()
 ##############################################################################
 # Dataset
 # --------------
-# For simplicity we will use a toy dataset where we denoise a noisy signal
+# For simplicity we will use a toy dataset based on a noisy sine
 from inferno.io.box.noisy_func_1d import get_noisy_func_loader
 
 import math

--- a/examples/plot_unet_1d.py
+++ b/examples/plot_unet_1d.py
@@ -1,0 +1,175 @@
+"""
+UNet Tutorial
+================================
+A unet example which can be run without a gpu
+"""
+
+##############################################################################
+# Preface
+# --------------
+# We start with some unspectacular multi purpose imports needed for this example
+import matplotlib.pyplot as plt
+import torch
+from torch import nn
+import numpy
+
+
+##############################################################################
+
+# determine whether we have a gpu
+# and should use cuda
+USE_CUDA = torch.cuda.is_available()
+
+
+##############################################################################
+# Dataset
+# --------------
+# For simplicity we will use a toy dataset where we denoise a noisy signal
+from inferno.io.box.noisy_func_1d import get_noisy_func_loader
+
+import math
+def f(i):
+    data = math.sin(float(i)/10.0)
+    return data, int(data>0.0)
+
+# convert labels from long to float as needed by
+# binary cross entropy loss
+def label_transform(x):
+    return torch.from_numpy(x).float()
+
+train_loader, test_loader, validate_loader = get_noisy_func_loader(
+    f=f,
+    size=20, # how many items per {train,test,validate}
+    train_batch_size=20,
+    test_batch_size=20,
+    signal_length=256, # <= length of array
+    sigma=1.2,
+    label_transform=label_transform
+)
+
+image_channels = 1   # <-- number of channels of the image
+pred_channels = 1  # <-- number of channels needed for the prediction
+
+if True:
+
+    # ##############################################################################
+    # # Visualize Dataset
+    # # ~~~~~~~~~~~~~~~~~~~~~~
+    fig = plt.figure()
+    for i,(noisy_signal, signal) in enumerate(train_loader):
+        ax = fig.add_subplot(2, 2, i+1)
+        ax.plot(numpy.arange(noisy_signal.size()[2]), noisy_signal.numpy()[0,0,...])#, 'ro')
+        ax.plot(numpy.arange(signal.size()[2]), signal.numpy()[0,0,...], 'r')
+        if i>=3 :
+            break
+    fig.tight_layout()
+    plt.show()
+
+
+
+
+##############################################################################
+# Training
+# ----------------------------
+# To train the unet, we use the infernos Trainer class of inferno.
+# Since we train many models later on in this example we encapsulate
+# the training in a function (see :ref:`sphx_glr_auto_examples_trainer.py` for
+# an example dedicated to the trainer itself).
+from inferno.trainers import Trainer
+from inferno.utils.python_utils import ensure_dir
+
+def train_model(model, loaders, **kwargs):
+
+    trainer = Trainer(model)
+    trainer.build_criterion('BCEWithLogitsLoss')
+    trainer.build_optimizer('Adam', lr=kwargs.get('lr', 0.0001))
+    trainer.validate_every((kwargs.get('validate_every', 1), 'epochs'))
+    #trainer.save_every((kwargs.get('save_every', 10), 'epochs'))
+    #trainer.save_to_directory(ensure_dir(kwargs.get('save_dir', 'save_dor')))
+    trainer.set_max_num_epochs(kwargs.get('max_num_epochs', 40))
+
+    # bind the loaders
+    trainer.bind_loader('train', loaders[0])
+    trainer.bind_loader('validate', loaders[1])
+
+    if USE_CUDA:
+        trainer.cuda()
+
+    # do the training
+    trainer.fit()
+
+    return trainer
+
+
+
+
+##############################################################################
+# Prediction
+# ----------------------------
+# The trainer contains the trained model and we can do predictions.
+# We use :code:`unwrap` to convert the results to numpy arrays.
+# Since we want to do many prediction we encapsulate the
+# the prediction in a function
+from inferno.utils.torch_utils import unwrap
+
+def predict(trainer, test_loader,  save_dir=None):
+
+
+    trainer.eval_mode()
+    c = 0
+    for noisy_signal, signal in test_loader:
+        if c > 2:
+            break
+        # transfer noisy_signal to gpu
+        noisy_signal = noisy_signal.cuda() if USE_CUDA else noisy_signal
+
+        # get batch size from noisy_signal
+        batch_size = noisy_signal.size()[0]
+
+        prediction = trainer.apply_model(noisy_signal)
+        prediction = torch.nn.functional.sigmoid(prediction)
+
+        noisy_signal = unwrap(noisy_signal,      as_numpy=True, to_cpu=True)
+        prediction = unwrap(prediction, as_numpy=True, to_cpu=True)
+        signal = unwrap(signal, as_numpy=True, to_cpu=True)
+
+        for b in range(batch_size):
+            fig = plt.figure()
+            rng = numpy.arange(prediction[b,...].size)
+
+            ax = fig.add_subplot(1, 1, 1)
+            ax.plot(rng,noisy_signal[b,0,...],'r' , rng,signal[b,0,...],'g', rng, prediction[b,0,...],'b')
+            fig.tight_layout()
+            plt.show()
+
+            c += 1
+            if c > 2:
+                break
+
+
+##############################################################################
+# Custom UNet
+# ----------------------------
+# Often one needs to have a UNet with custom layers.
+# Here we show how to implement such a customized UNet.
+# To this end we derive from :code:`UNetBase`.
+# For the sake of this example we will create
+# a Unet which uses depthwise convolutions and might be trained on a CPU
+from inferno.extensions.models import *
+from inferno.extensions.layers import *
+
+
+
+
+model_b = UNet( in_channels=1, out_channels=1, dim=1, depth=2)
+
+
+
+##################################################
+# do the training 
+trainer = train_model(model=model_b, loaders=[train_loader, validate_loader], save_dir='model_b', lr=0.001)
+
+###################################################
+# visualizer predictions
+predict(trainer=trainer, test_loader=test_loader)
+

--- a/inferno/extensions/layers/activations.py
+++ b/inferno/extensions/layers/activations.py
@@ -20,7 +20,7 @@ class SELU(nn.Module):
 def get_activation(activation):
     # get the final output and activation activation
     if isinstance(activation, str):
-        activation_mod = getattr(nn, final_activation)()
+        activation_mod = getattr(nn, activation)()
     elif isinstance(activation, nn.Module):
         activation_mod = activation
     elif activation is None:

--- a/inferno/extensions/layers/activations.py
+++ b/inferno/extensions/layers/activations.py
@@ -2,7 +2,7 @@ import torch.nn.functional as F
 import torch.nn as nn
 from ...utils.torch_utils import where
 
-__all__ = ['SELU']
+__all__ = ['SELU','get_activation']
 _all = __all__
 
 class SELU(nn.Module):
@@ -15,3 +15,16 @@ class SELU(nn.Module):
         scale = 1.0507009873554804934193349852946
         # noinspection PyTypeChecker
         return scale * where(x >= 0, x, alpha * F.elu(x))
+
+
+def get_activation(activation):
+    # get the final output and activation activation
+    if isinstance(activation, str):
+        activation_mod = getattr(nn, final_activation)()
+    elif isinstance(activation, nn.Module):
+        activation_mod = activation
+    elif activation is None:
+        activation_mod = None
+    else:
+        raise NotImplementedError("Activation of type %s is not supported" % type(activation))
+    return activation_mod

--- a/inferno/extensions/layers/convolutional.py
+++ b/inferno/extensions/layers/convolutional.py
@@ -7,17 +7,17 @@ from ...utils.exceptions import assert_, ShapeError
 
 
 __all__ = ['ConvActivation',
-           'ConvELU2D', 'ConvELU3D',
-           'ConvSigmoid2D', 'ConvSigmoid3D',
-           'DeconvELU2D', 'DeconvELU3D',
-           'StridedConvELU2D', 'StridedConvELU3D',
-           'DilatedConvELU2D', 'DilatedConvELU3D',
-           'Conv2D', 'Conv3D',
-           'BNReLUConv2D', 'BNReLUConv3D',
-           'BNReLUDepthwiseConv2D',
-           'ConvSELU2D', 'ConvSELU3D',
-           'ConvReLU2D', 'ConvReLU3D',
-           'BNReLUDilatedConv2D', 'DilatedConv2D',
+           'ConvELU1D', 'ConvELU2D', 'ConvELU3D',
+           'ConvSELU1D', 'ConvSELU2D', 'ConvSELU3D',
+           'ConvReLU1D', 'ConvReLU2D', 'ConvReLU3D',
+           'ConvSigmoid1D','ConvSigmoid2D', 'ConvSigmoid3D',
+           'DeconvELU1D','DeconvELU2D', 'DeconvELU3D',
+           'StridedConvELU1D', 'StridedConvELU2D', 'StridedConvELU3D',
+           'DilatedConvELU1D','DilatedConvELU2D', 'DilatedConvELU3D',
+           'Conv1D', 'Conv2D', 'Conv3D',
+           'BNReLUConv1D','BNReLUConv2D', 'BNReLUConv3D',
+           'BNReLUDepthwiseConv1D', 'BNReLUDepthwiseConv2D',
+           'BNReLUDilatedConv1D', 'BNReLUDilatedConv2D', 'DilatedConv2D','DilatedConv2D',
            'GlobalConv2D']
 _all = __all__
 
@@ -146,7 +146,7 @@ class ConvReLU3D(ConvActivation):
 class ConvELU1D(ConvActivation):
     """1D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
-        super(ConvELU2D, self).__init__(in_channels=in_channels,
+        super(ConvELU1D, self).__init__(in_channels=in_channels,
                                         out_channels=out_channels,
                                         kernel_size=kernel_size,
                                         dim=1,
@@ -389,7 +389,7 @@ class DilatedConvELU3D(ConvActivation):
 
 class DilatedConv1D(ConvActivation):
     """1D dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
-    def __init__(self, in_channels, out_channels, kernel_size, dilation=2)
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=2):
         super(DilatedConv1D, self).__init__(in_channels=in_channels,
                                                out_channels=out_channels,
                                                kernel_size=kernel_size,

--- a/inferno/extensions/layers/convolutional.py
+++ b/inferno/extensions/layers/convolutional.py
@@ -29,7 +29,7 @@ class ConvActivation(nn.Module):
                  deconv=False, initialization=None):
         super(ConvActivation, self).__init__()
         # Validate dim
-        assert_(dim in [2, 3], "`dim` must be one of [2, 3], got {}.".format(dim), ShapeError)
+        assert_(dim in [1, 2, 3], "`dim` must be one of [1, 2, 3], got {}.".format(dim), ShapeError)
         self.dim = dim
         # Check if depthwise
         if depthwise:
@@ -111,6 +111,48 @@ class ConvActivation(nn.Module):
         return tuple(padding)
 
 
+class ConvReLU1D(ConvActivation):
+    """1D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvReLU1D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=1,
+                                         activation='ReLU',
+                                         initialization=KaimingNormalWeightsZeroBias())
+
+class ConvReLU2D(ConvActivation):
+    """2D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvReLU2D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=2,
+                                         activation='ReLU',
+                                         initialization=KaimingNormalWeightsZeroBias())
+
+
+class ConvReLU3D(ConvActivation):
+    """3D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvReLU3D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=3,
+                                         activation='ReLU',
+                                         initialization=KaimingNormalWeightsZeroBias())
+
+
+class ConvELU1D(ConvActivation):
+    """1D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvELU2D, self).__init__(in_channels=in_channels,
+                                        out_channels=out_channels,
+                                        kernel_size=kernel_size,
+                                        dim=1,
+                                        activation='ELU',
+                                        initialization=OrthogonalWeightsZeroBias())
+
 class ConvELU2D(ConvActivation):
     """2D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
@@ -131,6 +173,68 @@ class ConvELU3D(ConvActivation):
                                         dim=3,
                                         activation='ELU',
                                         initialization=OrthogonalWeightsZeroBias())
+
+
+
+class ConvSELU1D(ConvActivation):
+    """1D Convolutional layer with SELU activation and the appropriate weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        if hasattr(nn, 'SELU'):
+            # Pytorch 0.2: Use built in SELU
+            activation = nn.SELU(inplace=True)
+        else:
+            # Pytorch < 0.1.12: Use handmade SELU
+            activation = SELU()
+        super(ConvSELU1D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=1,
+                                         activation=activation,
+                                         initialization=SELUWeightsZeroBias())
+
+class ConvSELU2D(ConvActivation):
+    """2D Convolutional layer with SELU activation and the appropriate weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        if hasattr(nn, 'SELU'):
+            # Pytorch 0.2: Use built in SELU
+            activation = nn.SELU(inplace=True)
+        else:
+            # Pytorch < 0.1.12: Use handmade SELU
+            activation = SELU()
+        super(ConvSELU2D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=2,
+                                         activation=activation,
+                                         initialization=SELUWeightsZeroBias())
+
+
+class ConvSELU3D(ConvActivation):
+    """3D Convolutional layer with SELU activation and the appropriate weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        if hasattr(nn, 'SELU'):
+            # Pytorch 0.2: Use built in SELU
+            activation = nn.SELU(inplace=True)
+        else:
+            # Pytorch < 0.1.12: Use handmade SELU
+            activation = SELU()
+        super(ConvSELU3D, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=3,
+                                         activation=activation,
+                                         initialization=SELUWeightsZeroBias())
+
+
+class ConvSigmoid1D(ConvActivation):
+    """1D Convolutional layer with 'SAME' padding, Sigmoid and orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size):
+        super(ConvSigmoid1D, self).__init__(in_channels=in_channels,
+                                            out_channels=out_channels,
+                                            kernel_size=kernel_size,
+                                            dim=1,
+                                            activation='Sigmoid',
+                                            initialization=OrthogonalWeightsZeroBias())
 
 
 class ConvSigmoid2D(ConvActivation):
@@ -155,6 +259,18 @@ class ConvSigmoid3D(ConvActivation):
                                             initialization=OrthogonalWeightsZeroBias())
 
 
+class DeconvELU1D(ConvActivation):
+    """1D deconvolutional layer with ELU and orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size=2):
+        super(DeconvELU1D, self).__init__(in_channels=in_channels,
+                                          out_channels=out_channels,
+                                          kernel_size=kernel_size,
+                                          dim=1,
+                                          activation='ELU',
+                                          deconv=True,
+                                          initialization=OrthogonalWeightsZeroBias())
+
+
 class DeconvELU2D(ConvActivation):
     """2D deconvolutional layer with ELU and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size=2):
@@ -177,6 +293,22 @@ class DeconvELU3D(ConvActivation):
                                           activation='ELU',
                                           deconv=True,
                                           initialization=OrthogonalWeightsZeroBias())
+
+
+
+class StridedConvELU1D(ConvActivation):
+    """
+    1D strided convolutional layer with 'SAME' padding, ELU and orthogonal
+    weight initialization.
+    """
+    def __init__(self , in_channels, out_channels, kernel_size, stride=2):
+        super(StridedConvELU1D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               stride=stride,
+                                               dim=1,
+                                               activation='ELU',
+                                               initialization=OrthogonalWeightsZeroBias())
 
 
 class StridedConvELU2D(ConvActivation):
@@ -209,6 +341,22 @@ class StridedConvELU3D(ConvActivation):
                                                initialization=OrthogonalWeightsZeroBias())
 
 
+
+
+class DilatedConvELU1D(ConvActivation):
+    """
+    1D dilated convolutional layer with 'SAME' padding, ELU and orthogonal
+    weight initialization.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=2):
+        super(DilatedConvELU1D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=1,
+                                               activation='ELU',
+                                               initialization=OrthogonalWeightsZeroBias())
+
 class DilatedConvELU2D(ConvActivation):
     """
     2D dilated convolutional layer with 'SAME' padding, ELU and orthogonal
@@ -238,6 +386,18 @@ class DilatedConvELU3D(ConvActivation):
                                                activation='ELU',
                                                initialization=OrthogonalWeightsZeroBias())
 
+
+class DilatedConv1D(ConvActivation):
+    """1D dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=2)
+        super(DilatedConv1D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=1,
+                                               activation=None,
+                                               initialization=OrthogonalWeightsZeroBias())
+
 class DilatedConv2D(ConvActivation):
     """2D dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size, dilation=2):
@@ -249,27 +409,34 @@ class DilatedConv2D(ConvActivation):
                                                activation=None,
                                                initialization=OrthogonalWeightsZeroBias())
 
+class DilatedConv3D(ConvActivation):
+    """3D dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=2):
+        super(DilatedConv3D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=3,
+                                               activation=None,
+                                               initialization=OrthogonalWeightsZeroBias())
 
-class ConvReLU2D(ConvActivation):
-    """2D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
-    def __init__(self, in_channels, out_channels, kernel_size):
-        super(ConvReLU2D, self).__init__(in_channels=in_channels,
-                                         out_channels=out_channels,
-                                         kernel_size=kernel_size,
-                                         dim=2,
-                                         activation='ReLU',
-                                         initialization=KaimingNormalWeightsZeroBias())
 
 
-class ConvReLU3D(ConvActivation):
-    """3D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
-    def __init__(self, in_channels, out_channels, kernel_size):
-        super(ConvReLU3D, self).__init__(in_channels=in_channels,
-                                         out_channels=out_channels,
-                                         kernel_size=kernel_size,
-                                         dim=3,
-                                         activation='ReLU',
-                                         initialization=KaimingNormalWeightsZeroBias())
+class Conv1D(ConvActivation):
+    """
+    1D convolutional layer with same padding and orthogonal weight initialization.
+    By default, this layer does not apply an activation function.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=1, stride=1,
+                 activation=None):
+        super(Conv1D, self).__init__(in_channels=in_channels,
+                                     out_channels=out_channels,
+                                     kernel_size=kernel_size,
+                                     dilation=dilation,
+                                     stride=stride,
+                                     dim=1,
+                                     activation=activation,
+                                     initialization=OrthogonalWeightsZeroBias())
 
 
 class Conv2D(ConvActivation):
@@ -304,6 +471,18 @@ class Conv3D(ConvActivation):
                                      dim=3,
                                      activation=activation,
                                      initialization=OrthogonalWeightsZeroBias())
+
+class Deconv1D(ConvActivation):
+    """1D deconvolutional layer with orthogonal weight initialization."""
+    def __init__(self, in_channels, out_channels, kernel_size=2, stride=2):
+        super(Deconv1D, self).__init__(in_channels=in_channels,
+                                       out_channels=out_channels,
+                                       kernel_size=kernel_size,
+                                       dim=1,
+                                       stride=stride,
+                                       activation=None,
+                                       deconv=True,
+                                       initialization=OrthogonalWeightsZeroBias())
 
 
 class Deconv2D(ConvActivation):
@@ -341,6 +520,21 @@ class _BNReLUSomeConv(object):
         return conved
 
 
+
+class BNReLUConv1D(_BNReLUSomeConv, ConvActivation):
+    """
+    1D BN-ReLU-Conv layer with 'SAME' padding and He weight initialization.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1):
+        super(BNReLUConv1D, self).__init__(in_channels=in_channels,
+                                           out_channels=out_channels,
+                                           kernel_size=kernel_size,
+                                           dim=1,
+                                           stride=stride,
+                                           activation=nn.ReLU(inplace=True),
+                                           initialization=KaimingNormalWeightsZeroBias(0))
+        self.batchnorm = nn.BatchNorm1d(in_channels)
+
 class BNReLUConv2D(_BNReLUSomeConv, ConvActivation):
     """
     2D BN-ReLU-Conv layer with 'SAME' padding and He weight initialization.
@@ -355,6 +549,22 @@ class BNReLUConv2D(_BNReLUSomeConv, ConvActivation):
                                            initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
 
+
+
+class BNReLUDilatedConv1D(_BNReLUSomeConv,ConvActivation):
+    """
+    1D dilated convolutional layer with 'SAME' padding, Batch norm,  Relu and He
+    weight initialization.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=1):
+        super(BNReLUDilatedConv1D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=1,
+                                               activation=nn.ReLU(inplace=True),
+                                               initialization=KaimingNormalWeightsZeroBias(0))
+        self.batchnorm = nn.BatchNorm2d(in_channels)
 
 class BNReLUDilatedConv2D(_BNReLUSomeConv,ConvActivation):
     """
@@ -385,6 +595,22 @@ class BNReLUConv3D(_BNReLUSomeConv, ConvActivation):
                                            activation=nn.ReLU(inplace=True),
                                            initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm3d(in_channels)
+
+
+class BNReLUDeconv1D(_BNReLUSomeConv, ConvActivation):
+    """
+    1D BN-ReLU-Deconv layer with He weight initialization and (default) stride 1.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, stride=2):
+        super(BNReLUDeconv1D, self).__init__(in_channels=in_channels,
+                                             out_channels=out_channels,
+                                             kernel_size=kernel_size,
+                                             dim=1,
+                                             stride=stride,
+                                             deconv=True,
+                                             activation=nn.ReLU(inplace=True),
+                                             initialization=KaimingNormalWeightsZeroBias(0))
+        self.batchnorm = nn.BatchNorm1d(in_channels)
 
 
 class BNReLUDeconv2D(_BNReLUSomeConv, ConvActivation):
@@ -419,6 +645,25 @@ class BNReLUDeconv3D(_BNReLUSomeConv, ConvActivation):
         self.batchnorm = nn.BatchNorm2d(in_channels)
 
 
+
+class BNReLUDepthwiseConv1D(_BNReLUSomeConv, ConvActivation):
+    """
+    1D BN-ReLU-Conv layer with 'SAME' padding, He weight initialization and depthwise convolution.
+    Note that depthwise convolutions require `in_channels == out_channels`.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size):
+        # We know that in_channels == out_channels, but we also want a consistent API.
+        # As a compromise, we allow that out_channels be None or 'auto'.
+        out_channels = in_channels if out_channels in [None, 'auto'] else out_channels
+        super(BNReLUDepthwiseConv1D, self).__init__(in_channels=in_channels,
+                                                    out_channels=out_channels,
+                                                    kernel_size=kernel_size,
+                                                    dim=1,
+                                                    depthwise=True,
+                                                    activation=nn.ReLU(inplace=True),
+                                                    initialization=KaimingNormalWeightsZeroBias(0))
+        self.batchnorm = nn.BatchNorm1d(in_channels)
+
 class BNReLUDepthwiseConv2D(_BNReLUSomeConv, ConvActivation):
     """
     2D BN-ReLU-Conv layer with 'SAME' padding, He weight initialization and depthwise convolution.
@@ -436,40 +681,6 @@ class BNReLUDepthwiseConv2D(_BNReLUSomeConv, ConvActivation):
                                                     activation=nn.ReLU(inplace=True),
                                                     initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
-
-
-class ConvSELU2D(ConvActivation):
-    """2D Convolutional layer with SELU activation and the appropriate weight initialization."""
-    def __init__(self, in_channels, out_channels, kernel_size):
-        if hasattr(nn, 'SELU'):
-            # Pytorch 0.2: Use built in SELU
-            activation = nn.SELU(inplace=True)
-        else:
-            # Pytorch < 0.1.12: Use handmade SELU
-            activation = SELU()
-        super(ConvSELU2D, self).__init__(in_channels=in_channels,
-                                         out_channels=out_channels,
-                                         kernel_size=kernel_size,
-                                         dim=2,
-                                         activation=activation,
-                                         initialization=SELUWeightsZeroBias())
-
-
-class ConvSELU3D(ConvActivation):
-    """3D Convolutional layer with SELU activation and the appropriate weight initialization."""
-    def __init__(self, in_channels, out_channels, kernel_size):
-        if hasattr(nn, 'SELU'):
-            # Pytorch 0.2: Use built in SELU
-            activation = nn.SELU(inplace=True)
-        else:
-            # Pytorch < 0.1.12: Use handmade SELU
-            activation = SELU()
-        super(ConvSELU3D, self).__init__(in_channels=in_channels,
-                                         out_channels=out_channels,
-                                         kernel_size=kernel_size,
-                                         dim=3,
-                                         activation=activation,
-                                         initialization=SELUWeightsZeroBias())
 
 
 class GlobalConv2D(nn.Module):

--- a/inferno/extensions/layers/convolutional.py
+++ b/inferno/extensions/layers/convolutional.py
@@ -7,17 +7,18 @@ from ...utils.exceptions import assert_, ShapeError
 
 
 __all__ = ['ConvActivation',
-           'ConvELU1D', 'ConvELU2D', 'ConvELU3D',
-           'ConvSELU1D', 'ConvSELU2D', 'ConvSELU3D',
-           'ConvReLU1D', 'ConvReLU2D', 'ConvReLU3D',
-           'ConvSigmoid1D','ConvSigmoid2D', 'ConvSigmoid3D',
-           'DeconvELU1D','DeconvELU2D', 'DeconvELU3D',
-           'StridedConvELU1D', 'StridedConvELU2D', 'StridedConvELU3D',
-           'DilatedConvELU1D','DilatedConvELU2D', 'DilatedConvELU3D',
-           'Conv1D', 'Conv2D', 'Conv3D',
-           'BNReLUConv1D','BNReLUConv2D', 'BNReLUConv3D',
-           'BNReLUDepthwiseConv1D', 'BNReLUDepthwiseConv2D',
-           'BNReLUDilatedConv1D', 'BNReLUDilatedConv2D', 'DilatedConv2D','DilatedConv2D',
+           'ConvELU','ConvELU1D', 'ConvELU2D', 'ConvELU3D',
+           'ConvSELU','ConvSELU1D', 'ConvSELU2D', 'ConvSELU3D',
+           'ConvReLU','ConvReLU1D', 'ConvReLU2D', 'ConvReLU3D',
+           'ConvSigmoid','ConvSigmoid1D','ConvSigmoid2D', 'ConvSigmoid3D',
+           'DeconvELU','DeconvELU1D','DeconvELU2D', 'DeconvELU3D',
+           'StridedConvELU','StridedConvELU1D', 'StridedConvELU2D', 'StridedConvELU3D',
+           'DilatedConvELU','DilatedConvELU1D','DilatedConvELU2D', 'DilatedConvELU3D',
+           'Conv','Conv1D', 'Conv2D', 'Conv3D',
+           'BNReLUConv','BNReLUConv1D','BNReLUConv2D', 'BNReLUConv3D',
+           'BNReLUDepthwiseConv','BNReLUDepthwiseConv1D', 'BNReLUDepthwiseConv2D',
+           'BNReLUDilatedConv','BNReLUDilatedConv1D', 'BNReLUDilatedConv2D', 
+           'DilatedConv','DilatedConv2D','DilatedConv3D',
            'GlobalConv2D']
 _all = __all__
 
@@ -110,6 +111,15 @@ class ConvActivation(nn.Module):
                    for _kernel_size, _dilation in zip(kernel_size, dilation)]
         return tuple(padding)
 
+class ConvReLU(ConvActivation):
+    """Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size):
+        super(ConvReLU, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=dim,
+                                         activation='ReLU',
+                                         initialization=KaimingNormalWeightsZeroBias())
 
 class ConvReLU1D(ConvActivation):
     """1D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
@@ -131,7 +141,6 @@ class ConvReLU2D(ConvActivation):
                                          activation='ReLU',
                                          initialization=KaimingNormalWeightsZeroBias())
 
-
 class ConvReLU3D(ConvActivation):
     """3D Convolutional layer with 'SAME' padding, ReLU and Kaiming normal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
@@ -142,6 +151,15 @@ class ConvReLU3D(ConvActivation):
                                          activation='ReLU',
                                          initialization=KaimingNormalWeightsZeroBias())
 
+class ConvELU(ConvActivation):
+    """1D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size):
+        super(ConvELU, self).__init__(in_channels=in_channels,
+                                        out_channels=out_channels,
+                                        kernel_size=kernel_size,
+                                        dim=dim,
+                                        activation='ELU',
+                                        initialization=OrthogonalWeightsZeroBias())
 
 class ConvELU1D(ConvActivation):
     """1D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
@@ -163,7 +181,6 @@ class ConvELU2D(ConvActivation):
                                         activation='ELU',
                                         initialization=OrthogonalWeightsZeroBias())
 
-
 class ConvELU3D(ConvActivation):
     """3D Convolutional layer with 'SAME' padding, ELU and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
@@ -174,6 +191,21 @@ class ConvELU3D(ConvActivation):
                                         activation='ELU',
                                         initialization=OrthogonalWeightsZeroBias())
 
+class ConvSELU(ConvActivation):
+    """Convolutional layer with SELU activation and the appropriate weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size):
+        if hasattr(nn, 'SELU'):
+            # Pytorch 0.2: Use built in SELU
+            activation = nn.SELU(inplace=True)
+        else:
+            # Pytorch < 0.1.12: Use handmade SELU
+            activation = SELU()
+        super(ConvSELU, self).__init__(in_channels=in_channels,
+                                         out_channels=out_channels,
+                                         kernel_size=kernel_size,
+                                         dim=dim,
+                                         activation=activation,
+                                         initialization=SELUWeightsZeroBias())
 
 
 class ConvSELU1D(ConvActivation):
@@ -208,7 +240,6 @@ class ConvSELU2D(ConvActivation):
                                          activation=activation,
                                          initialization=SELUWeightsZeroBias())
 
-
 class ConvSELU3D(ConvActivation):
     """3D Convolutional layer with SELU activation and the appropriate weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
@@ -225,6 +256,15 @@ class ConvSELU3D(ConvActivation):
                                          activation=activation,
                                          initialization=SELUWeightsZeroBias())
 
+class ConvSigmoid(ConvActivation):
+    """Convolutional layer with 'SAME' padding, Sigmoid and orthogonal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size):
+        super(ConvSigmoid, self).__init__(in_channels=in_channels,
+                                            out_channels=out_channels,
+                                            kernel_size=kernel_size,
+                                            dim=dim,
+                                            activation='Sigmoid',
+                                            initialization=OrthogonalWeightsZeroBias())
 
 class ConvSigmoid1D(ConvActivation):
     """1D Convolutional layer with 'SAME' padding, Sigmoid and orthogonal weight initialization."""
@@ -236,7 +276,6 @@ class ConvSigmoid1D(ConvActivation):
                                             activation='Sigmoid',
                                             initialization=OrthogonalWeightsZeroBias())
 
-
 class ConvSigmoid2D(ConvActivation):
     """2D Convolutional layer with 'SAME' padding, Sigmoid and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size):
@@ -246,7 +285,6 @@ class ConvSigmoid2D(ConvActivation):
                                             dim=2,
                                             activation='Sigmoid',
                                             initialization=OrthogonalWeightsZeroBias())
-
 
 class ConvSigmoid3D(ConvActivation):
     """3D Convolutional layer with 'SAME' padding, Sigmoid and orthogonal weight initialization."""
@@ -258,6 +296,16 @@ class ConvSigmoid3D(ConvActivation):
                                             activation='Sigmoid',
                                             initialization=OrthogonalWeightsZeroBias())
 
+class DeconvELU(ConvActivation):
+    """deconvolutional layer with ELU and orthogonal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size=2):
+        super(DeconvELU, self).__init__(in_channels=in_channels,
+                                          out_channels=out_channels,
+                                          kernel_size=kernel_size,
+                                          dim=dim,
+                                          activation='ELU',
+                                          deconv=True,
+                                          initialization=OrthogonalWeightsZeroBias())
 
 class DeconvELU1D(ConvActivation):
     """1D deconvolutional layer with ELU and orthogonal weight initialization."""
@@ -270,7 +318,6 @@ class DeconvELU1D(ConvActivation):
                                           deconv=True,
                                           initialization=OrthogonalWeightsZeroBias())
 
-
 class DeconvELU2D(ConvActivation):
     """2D deconvolutional layer with ELU and orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size=2):
@@ -281,7 +328,6 @@ class DeconvELU2D(ConvActivation):
                                           activation='ELU',
                                           deconv=True,
                                           initialization=OrthogonalWeightsZeroBias())
-
 
 class DeconvELU3D(ConvActivation):
     """3D deconvolutional layer with ELU and orthogonal weight initialization."""
@@ -294,7 +340,19 @@ class DeconvELU3D(ConvActivation):
                                           deconv=True,
                                           initialization=OrthogonalWeightsZeroBias())
 
-
+class StridedConvELU(ConvActivation):
+    """
+    strided convolutional layer with 'SAME' padding, ELU and orthogonal
+    weight initialization.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size, stride=2):
+        super(StridedConvELU, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               stride=stride,
+                                               dim=dim,
+                                               activation='ELU',
+                                               initialization=OrthogonalWeightsZeroBias())
 
 class StridedConvELU1D(ConvActivation):
     """
@@ -310,7 +368,6 @@ class StridedConvELU1D(ConvActivation):
                                                activation='ELU',
                                                initialization=OrthogonalWeightsZeroBias())
 
-
 class StridedConvELU2D(ConvActivation):
     """
     2D strided convolutional layer with 'SAME' padding, ELU and orthogonal
@@ -325,7 +382,6 @@ class StridedConvELU2D(ConvActivation):
                                                activation='ELU',
                                                initialization=OrthogonalWeightsZeroBias())
 
-
 class StridedConvELU3D(ConvActivation):
     """
     2D strided convolutional layer with 'SAME' padding, ELU and orthogonal
@@ -338,10 +394,21 @@ class StridedConvELU3D(ConvActivation):
                                                stride=stride,
                                                dim=3,
                                                activation='ELU',
+
                                                initialization=OrthogonalWeightsZeroBias())
-
-
-
+class DilatedConvELU(ConvActivation):
+    """
+    dilated convolutional layer with 'SAME' padding, ELU and orthogonal
+    weight initialization.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size, dilation=2):
+        super(DilatedConvELU, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=dim,
+                                               activation='ELU',
+                                               initialization=OrthogonalWeightsZeroBias())
 
 class DilatedConvELU1D(ConvActivation):
     """
@@ -371,7 +438,6 @@ class DilatedConvELU2D(ConvActivation):
                                                activation='ELU',
                                                initialization=OrthogonalWeightsZeroBias())
 
-
 class DilatedConvELU3D(ConvActivation):
     """
     3D dilated convolutional layer with 'SAME' padding, ELU and orthogonal
@@ -385,7 +451,16 @@ class DilatedConvELU3D(ConvActivation):
                                                dim=3,
                                                activation='ELU',
                                                initialization=OrthogonalWeightsZeroBias())
-
+class DilatedConv(ConvActivation):
+    """dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size, dilation=2):
+        super(DilatedConv, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=dim,
+                                               activation=None,
+                                               initialization=OrthogonalWeightsZeroBias())
 
 class DilatedConv1D(ConvActivation):
     """1D dilated convolutional layer with 'SAME' padding, no activation and orthogonal weight initialization."""
@@ -420,7 +495,21 @@ class DilatedConv3D(ConvActivation):
                                                activation=None,
                                                initialization=OrthogonalWeightsZeroBias())
 
-
+class Conv(ConvActivation):
+    """
+    convolutional layer with same padding and orthogonal weight initialization.
+    By default, this layer does not apply an activation function.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size, dilation=1, stride=1,
+                 activation=None):
+        super(Conv, self).__init__(in_channels=in_channels,
+                                     out_channels=out_channels,
+                                     kernel_size=kernel_size,
+                                     dilation=dilation,
+                                     stride=stride,
+                                     dim=dim,
+                                     activation=activation,
+                                     initialization=OrthogonalWeightsZeroBias())
 
 class Conv1D(ConvActivation):
     """
@@ -438,7 +527,6 @@ class Conv1D(ConvActivation):
                                      activation=activation,
                                      initialization=OrthogonalWeightsZeroBias())
 
-
 class Conv2D(ConvActivation):
     """
     2D convolutional layer with same padding and orthogonal weight initialization.
@@ -454,7 +542,6 @@ class Conv2D(ConvActivation):
                                      dim=2,
                                      activation=activation,
                                      initialization=OrthogonalWeightsZeroBias())
-
 
 class Conv3D(ConvActivation):
     """
@@ -472,6 +559,17 @@ class Conv3D(ConvActivation):
                                      activation=activation,
                                      initialization=OrthogonalWeightsZeroBias())
 
+class Deconv(ConvActivation):
+    """deconvolutional layer with orthogonal weight initialization."""
+    def __init__(self, dim, in_channels, out_channels, kernel_size=2, stride=2):
+        super(Deconv, self).__init__(in_channels=in_channels,
+                                       out_channels=out_channels,
+                                       kernel_size=kernel_size,
+                                       dim=dim,
+                                       stride=stride,
+                                       activation=None,
+                                       deconv=True,
+                                       initialization=OrthogonalWeightsZeroBias())
 class Deconv1D(ConvActivation):
     """1D deconvolutional layer with orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size=2, stride=2):
@@ -483,7 +581,6 @@ class Deconv1D(ConvActivation):
                                        activation=None,
                                        deconv=True,
                                        initialization=OrthogonalWeightsZeroBias())
-
 
 class Deconv2D(ConvActivation):
     """2D deconvolutional layer with orthogonal weight initialization."""
@@ -497,7 +594,6 @@ class Deconv2D(ConvActivation):
                                        deconv=True,
                                        initialization=OrthogonalWeightsZeroBias())
 
-
 class Deconv3D(ConvActivation):
     """2D deconvolutional layer with orthogonal weight initialization."""
     def __init__(self, in_channels, out_channels, kernel_size=2, stride=2):
@@ -510,7 +606,6 @@ class Deconv3D(ConvActivation):
                                        deconv=True,
                                        initialization=OrthogonalWeightsZeroBias())
 
-
 # noinspection PyUnresolvedReferences
 class _BNReLUSomeConv(object):
     def forward(self, input):
@@ -519,7 +614,20 @@ class _BNReLUSomeConv(object):
         conved = self.conv(activated)
         return conved
 
-
+class BNReLUConv(_BNReLUSomeConv, ConvActivation):
+    """
+    BN-ReLU-Conv layer with 'SAME' padding and He weight initialization.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size, stride=1):
+        super(BNReLUConv, self).__init__(in_channels=in_channels,
+                                           out_channels=out_channels,
+                                           kernel_size=kernel_size,
+                                           dim=dim,
+                                           stride=stride,
+                                           activation=nn.ReLU(inplace=True),
+                                           initialization=KaimingNormalWeightsZeroBias(0))
+        BatchNormNd = getattr(nn, 'BatchNorm{0}d'.format(int(dim)))
+        self.batchnorm = BatchNormNd(in_channels)
 
 class BNReLUConv1D(_BNReLUSomeConv, ConvActivation):
     """
@@ -549,7 +657,35 @@ class BNReLUConv2D(_BNReLUSomeConv, ConvActivation):
                                            initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
 
+class BNReLUConv3D(_BNReLUSomeConv, ConvActivation):
+    """
+    3D BN-ReLU-Conv layer with 'SAME' padding and He weight initialization.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1):
+        super(BNReLUConv3D, self).__init__(in_channels=in_channels,
+                                           out_channels=out_channels,
+                                           kernel_size=kernel_size,
+                                           dim=3,
+                                           stride=stride,
+                                           activation=nn.ReLU(inplace=True),
+                                           initialization=KaimingNormalWeightsZeroBias(0))
+        self.batchnorm = nn.BatchNorm3d(in_channels)
 
+class BNReLUDilatedConv(_BNReLUSomeConv,ConvActivation):
+    """
+    dilated convolutional layer with 'SAME' padding, Batch norm,  Relu and He
+    weight initialization.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size, dilation=1):
+        super(BNReLUDilatedConv1D, self).__init__(in_channels=in_channels,
+                                               out_channels=out_channels,
+                                               kernel_size=kernel_size,
+                                               dilation=dilation,
+                                               dim=dim,
+                                               activation=nn.ReLU(inplace=True),
+                                               initialization=KaimingNormalWeightsZeroBias(0))
+        BatchNormNd = getattr(nn, 'BatchNorm{0}d'.format(int(dim)))
+        self.batchnorm = BatchNormNd(in_channels)
 
 class BNReLUDilatedConv1D(_BNReLUSomeConv,ConvActivation):
     """
@@ -581,21 +717,21 @@ class BNReLUDilatedConv2D(_BNReLUSomeConv,ConvActivation):
                                                initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
 
-
-class BNReLUConv3D(_BNReLUSomeConv, ConvActivation):
+class BNReLUDeconv(_BNReLUSomeConv, ConvActivation):
     """
-    3D BN-ReLU-Conv layer with 'SAME' padding and He weight initialization.
+    BN-ReLU-Deconv layer with He weight initialization and (default) stride 1.
     """
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1):
-        super(BNReLUConv3D, self).__init__(in_channels=in_channels,
-                                           out_channels=out_channels,
-                                           kernel_size=kernel_size,
-                                           dim=3,
-                                           stride=stride,
-                                           activation=nn.ReLU(inplace=True),
-                                           initialization=KaimingNormalWeightsZeroBias(0))
-        self.batchnorm = nn.BatchNorm3d(in_channels)
-
+    def __init__(self, dim, in_channels, out_channels, kernel_size, stride=2):
+        super(BNReLUDeconv, self).__init__(in_channels=in_channels,
+                                             out_channels=out_channels,
+                                             kernel_size=kernel_size,
+                                             dim=dim,
+                                             stride=stride,
+                                             deconv=True,
+                                             activation=nn.ReLU(inplace=True),
+                                             initialization=KaimingNormalWeightsZeroBias(0))
+        BatchNormNd = getattr(nn, 'BatchNorm{0}d'.format(int(dim)))
+        self.batchnorm = BatchNormNd(in_channels)
 
 class BNReLUDeconv1D(_BNReLUSomeConv, ConvActivation):
     """
@@ -612,7 +748,6 @@ class BNReLUDeconv1D(_BNReLUSomeConv, ConvActivation):
                                              initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm1d(in_channels)
 
-
 class BNReLUDeconv2D(_BNReLUSomeConv, ConvActivation):
     """
     2D BN-ReLU-Deconv layer with He weight initialization and (default) stride 2.
@@ -627,7 +762,6 @@ class BNReLUDeconv2D(_BNReLUSomeConv, ConvActivation):
                                              activation=nn.ReLU(inplace=True),
                                              initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
-
 
 class BNReLUDeconv3D(_BNReLUSomeConv, ConvActivation):
     """
@@ -644,6 +778,24 @@ class BNReLUDeconv3D(_BNReLUSomeConv, ConvActivation):
                                              initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
 
+class BNReLUDepthwiseConv(_BNReLUSomeConv, ConvActivation):
+    """
+    1D BN-ReLU-Conv layer with 'SAME' padding, He weight initialization and depthwise convolution.
+    Note that depthwise convolutions require `in_channels == out_channels`.
+    """
+    def __init__(self, dim, in_channels, out_channels, kernel_size):
+        # We know that in_channels == out_channels, but we also want a consistent API.
+        # As a compromise, we allow that out_channels be None or 'auto'.
+        out_channels = in_channels if out_channels in [None, 'auto'] else out_channels
+        super(BNReLUDepthwiseConv, self).__init__(in_channels=in_channels,
+                                                    out_channels=out_channels,
+                                                    kernel_size=kernel_size,
+                                                    dim=dim,
+                                                    depthwise=True,
+                                                    activation=nn.ReLU(inplace=True),
+                                                    initialization=KaimingNormalWeightsZeroBias(0))
+        BatchNormNd = getattr(nn, 'BatchNorm{0}d'.format(int(dim)))
+        self.batchnorm = BatchNormNd(in_channels)
 
 
 class BNReLUDepthwiseConv1D(_BNReLUSomeConv, ConvActivation):
@@ -681,7 +833,6 @@ class BNReLUDepthwiseConv2D(_BNReLUSomeConv, ConvActivation):
                                                     activation=nn.ReLU(inplace=True),
                                                     initialization=KaimingNormalWeightsZeroBias(0))
         self.batchnorm = nn.BatchNorm2d(in_channels)
-
 
 class GlobalConv2D(nn.Module):
     """From https://arxiv.org/pdf/1703.02719.pdf

--- a/inferno/extensions/models/res_unet.py
+++ b/inferno/extensions/models/res_unet.py
@@ -155,7 +155,7 @@ class _ResBlock(_ResBlockBase):
 
 
 # TODO not sure how to handle out-channels properly.
-# For now, we just force the corrcect number in the last decoder layer
+# For now, we just force the correct number in the last decoder layer
 class ResBlockUNet(UNetBase):
     """TODO.
 

--- a/inferno/io/box/noisy_func_1d.py
+++ b/inferno/io/box/noisy_func_1d.py
@@ -1,0 +1,77 @@
+import torch.utils.data as data
+import numpy
+
+
+class NoisyFunc(data.Dataset):
+
+
+    def __init__(self, f, size, signal_length, sigma, split, label_transform=None):
+        # the f
+        self.f = f
+
+        # how many images are in the dataset
+        self.size = size
+
+        # blob related members
+        self.signal_length             = signal_length
+
+        # noise related members
+        self.sigma = sigma
+
+        # which split {'train', 'test', 'validate'}
+        self.split              = split
+
+        self.label_transform = label_transform
+
+        # internal
+        split_to_seed = dict(train=0, test=1, validate=2)
+        self.master_seed  = split_to_seed[self.split]*self.size
+
+        
+    def __getitem__(self, index):
+        numpy.random.seed(seed=self.master_seed + index)
+
+        signal = numpy.zeros(self.signal_length, dtype=numpy.float32)
+        gt = numpy.zeros(self.signal_length, dtype=numpy.int32)
+        for i in range(self.signal_length):
+            d,l = self.f(i)
+            signal[i] = d
+            gt[i] = l
+
+        if self.label_transform is not None:
+                gt = self.label_transform(gt)
+
+        noisy_signal = signal.copy()
+
+        # add gaussian noise
+        noisy_signal += numpy.random.normal(scale=self.sigma,size=self.signal_length)
+        
+        
+        # add singletons for channels
+        return noisy_signal[None,...], gt[None,...]
+
+    def __len__(self):
+        return self.size
+
+
+def get_noisy_func_loader(f, size, signal_length, sigma,train_batch_size=1, test_batch_size=1,
+                            num_workers=1, label_transform=None):
+    
+    trainset = NoisyFunc(split='train',     f=f, size=size, signal_length=signal_length, sigma=sigma, label_transform=label_transform)
+    testset  = NoisyFunc(split='test',      f=f, size=size, signal_length=signal_length, sigma=sigma, label_transform=label_transform)
+    validset = NoisyFunc(split='validate',  f=f, size=size, signal_length=signal_length, sigma=sigma, label_transform=label_transform)
+
+
+    trainloader = data.DataLoader(trainset, batch_size=train_batch_size,
+                                            num_workers=num_workers)
+
+    testloader = data.DataLoader(testset, batch_size=test_batch_size,
+                                            num_workers=num_workers)
+
+    validloader = data.DataLoader(validset, batch_size=test_batch_size,
+                                            num_workers=num_workers)
+
+    return trainloader, testloader, validloader
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
-from inferno import __version__
+#from inferno.version import __version__
+import runpy
+__version__ = runpy.run_path('inferno/version.py')['__version__']
+
+
+
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
This PR adds the following:

Convolutions:
 - 1D convenient classes for all convolutions
 - ND convenient classes for all convolutions ( eg `ConvELU` where `dim` is a keyword of the constructor,  only 1D, 2D, and 3D works)

UNetBase:
 - major refactoring of `UNetBase`: 
   - added **start block** and **end block**, this allows for an easier implementation of `UNet`.
The start block can be used to increase the features from `in_channels` to `initial_features` before the actual unet, the end block is used to convert the output features of the unet to the desired number of channels (@constantinpape what do you think about theses changes)
   - cleaned code

This is still a work in progress, the ResUnet still needs the refactoring, also the examples are not yet up-to date