### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
-from inferno import __version__
+import runpy
+__version__ = runpy.run_path('inferno/version.py')['__version__']
+
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
we cannot use statements as `import inferno.__version__` in the setup.py since this statment is going to evaluate `inferno.__init__.py`
This leads to many errors, in particular missing dependencies if one has not yet installed infernos dependencies yet 
```
    from inferno.version import __version__
  File "/home/thorsten/src/inferno/inferno/__init__.py", line 5, in <module>
    from . import extensions
  File "/home/thorsten/src/inferno/inferno/extensions/__init__.py", line 1, in <module>
    from . import containers
  File "/home/thorsten/src/inferno/inferno/extensions/containers/__init__.py", line 1, in <module>
    from .graph import *
  File "/home/thorsten/src/inferno/inferno/extensions/containers/graph.py", line 8, in <module>
    import networkx as nx
ModuleNotFoundError: No module named 'networkx'
```