### PR TITLE
changed view to copy

### DIFF
--- a/inferno/io/transform/volume.py
+++ b/inferno/io/transform/volume.py
@@ -18,11 +18,11 @@ class RandomFlip3D(Transform):
 
     def volume_function(self, volume):
         if self.get_random_variable('flip_lr'):
-            volume = volume[:, :, ::-1]
+            volume = volume[:, :, ::-1].copy()
         if self.get_random_variable('flip_ud'):
-            volume = volume[:, ::-1, :]
+            volume = volume[:, ::-1, :].copy()
         if self.get_random_variable('flip_z'):
-            volume = volume[::-1, :, :]
+            volume = volume[::-1, :, :].copy()
         return volume
 
 


### PR DESCRIPTION
If torch.from_numpy is applied directly after RandomFlip3D it might complain that the negative strides are not supported. That is why we have to return a copy, not a view